### PR TITLE
incorporated ldap with loginmodal

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -6,3 +6,4 @@ reactive-var
 msavin:mongol
 meteorstuff:materialize-modal
 tdamsma:meteor-accounts-ldap
+aldeed:template-extension

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,4 +1,5 @@
 accounts-base@1.2.1
+aldeed:template-extension@4.0.0
 autoupdate@1.2.3
 babel-compiler@5.8.24_1
 babel-runtime@0.1.4

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ To run CalvinBookshelf on local host in this phase of development you need to:
 
 1. Enter admin user and password credentials under `bindCn` and `bindPassword` in the config/settings.json file.
 
-2. Run meteor using `meteor --settings config/settings.json`
+2. Run meteor using `meteor --settings lib/settings.json`
 
 Alternatively, checkout the deployed prototype at calvinbookshelf.meteor.com

--- a/client/views/base/header.html
+++ b/client/views/base/header.html
@@ -1,7 +1,7 @@
 <!-- Website Header. Contains Buy and Sell links.  -->
 <template name="header">
   <nav class="top-nav cyan">
-    <div class="nav-wrapper">
+    <div id="nav" class="nav-wrapper">
       <a href="{{pathFor route='home'}}" class="brand-logo left">
         <img class="responsive-img" src="images/Calvin Bookshelf Branding_White Text.png" style="max-height: 54px; padding: 6px; vertical-align: middle;">
       </a>
@@ -9,10 +9,23 @@
         <i class="material-icons">menu</i>
       </a>
       <ul id="nav-mobile" class="right hide-on-med-and-down">
-        <li><a href="{{pathFor route='home'}}">Search</a></li>
-        <li><a href="{{pathFor route='sell'}}">Sell</a></li>
+        <li><a href="{{pathFor route='sell'}}">Sell Book</a></li>
+        {{#if currentUser}}
+        <!-- dropdown trigger currently not working -->
+        <li><a class='dropdown-button btn-flat white-text' href='#' data-activates='userAccountDropdown'>Hi, {{currentUser.username}}</a></li>
+        <!-- Dropdown Structure -->
+        <ul id='userAccountDropdown' class='dropdown-content'>
+          <li><a href="{{pathFor route='account'}}">My Account</a></li>
+          <!-- log out function to be implemented eventually-->
+          <li><a href="#!">Log out</a></li>
+        </ul>
+        {{else}}
+        <!--loginModal trigger currently not working-->
+        <li><a href="#" name="login">Log in</a></li>
+        {{/if}}
       </ul>
     </div>
   </nav>
   {{> loginModal}}
 </template>
+        

--- a/client/views/modals/modals.html
+++ b/client/views/modals/modals.html
@@ -1,22 +1,53 @@
 <!-- a modal that prompts the user to log in -->
 <template name="loginModal">
   <div id="loginModal" class="modal">
-    {{> ldapLogin}}
-    <!-- <div class="modal-content">
-      <h3 class="grey-text text-darken-4 center-align">Login</h3>
-      <form id="loginForm" class="col s12">
-        <div class="row">
-          {{> inputField emailField}}
-          {{> inputField passwordField}}
-        </div>
-      </form>
-    </div>
-    <div class="modal-footer">
-      {{> button cancelButton}}
-      {{> button loginButton}}
-    </div> -->
+    {{> myLdapLogin}}
   </div>
 </template>
+
+<!--a template that replaces ldapLogin from tdamsma:meteor-accounts-ldap package with nicer UI-->
+<template name="myLdapLogin">
+<!--temporary if currently logged in pop up that will be removed eventually-->
+{{#if currentUser}}
+  <div class="navbar-username" style="inline-block">Welcome, {{currentUser.username}}. <button class="btn-flat transparent waves-effect waves-red" name="logout">Logout</button></div>
+{{else}}
+  {{#if loggingIn}}
+    <div class="logging-in">
+      Logging in...
+    </div>
+  {{else}}
+    <div class="modal-content">
+      <h3 class="grey-text text-darken-4 center-align">Login</h3>
+      <form name="loginForm" class="col s12">
+        <!--input names must be ldap and password respectively for tdamsma:meteor-accounts-ldap package-->
+        <div row>
+          <div class="input-field col s8 offset-s2">
+            <i class="material-icons prefix">account_circle</i>
+            <input id="email" type="text" name="ldap" class="validate" required>
+            <label for="ldap">Calvin Username</label>
+          </div>
+          <div class="input-field col s8 offset-s2">
+            <i class="material-icons prefix">lock</i>
+            <input id="password" type="password" name="password" class="validate" required>
+            <label for="password">Calvin Password</label>
+          </div>
+        </div>
+      </form>
+      <h6 class="grey-text text-lighten-1 center-align">*Don't worry, we don't save your password</h6>
+    </div>
+    <div class="modal-footer">
+      <button class="btn-flat transparent waves-effect waves-red modal-close">Cancel</button>
+      <button class="btn-flat transparent waves-effect waves-green" name="login" type="submit" form="loginForm">Login</button>
+    </div>
+    {{#if failedLogin}}
+      <div class="loginError">
+        <span style="color:red">Invalid Username or Password.</span>
+      </div>
+    {{/if}}
+  {{/if}}
+{{/if}}
+</template>
+
 
 <!-- a simple button template that's nice for buttons with many classes -->
 <template name="button">

--- a/client/views/modals/modals.js
+++ b/client/views/modals/modals.js
@@ -8,15 +8,10 @@ Template.loginModal.onRendered(function() {
     });
 });
 
-// an event handler that's bound to the loginModal template
-Template.loginModal.events({
-    "submit #loginForm": function (event) {
-        event.preventDefault();
-        var email = event.target.email.value;
-        var password = event.target.password.value;
-        Materialize.toast("Logged in as " + email, 2000, 'rounded');
-    }
-});
+// modified myLdapLogin template inherits from ldapLogin of tdamsma:meteor-accounts-ldap package
+Template.myLdapLogin.inheritsHelpersFrom("ldapLogin");
+Template.myLdapLogin.inheritsEventsFrom("ldapLogin");
+Template.myLdapLogin.inheritsHooksFrom("ldapLogin");
 
 // helper functions that are bound to the loginModal template
 Template.loginModal.helpers({
@@ -24,6 +19,7 @@ Template.loginModal.helpers({
         return {
             icon: "account_circle",
             type: "email",
+            name: "ldap",
             label: "Calvin Email"
         }
     },
@@ -31,6 +27,7 @@ Template.loginModal.helpers({
         return {
             icon: "lock",
             type: "password",
+            name: "password",
             label: "Calvin Password"
         }
     },

--- a/client/views/pages/account.html
+++ b/client/views/pages/account.html
@@ -1,0 +1,8 @@
+<!-- stub for a page that displays a user's account information  -->
+<template name="account">
+  <div class="container">
+    <div class="row">
+      <h3 class="header center-align">My Books:</h3>
+    </div>
+  </div>
+</template>

--- a/lib/router.js
+++ b/lib/router.js
@@ -13,3 +13,4 @@ Router.route('/about');
 Router.route('/results');
 Router.route('/sell');
 Router.route('/buy');
+Router.route('/account');

--- a/lib/settings.json
+++ b/lib/settings.json
@@ -11,7 +11,7 @@
             "givenName"
         ],
         "groupMembership": [
-            "Students"
+            "Student"
         ]
     }
 }


### PR DESCRIPTION
- template myLdapLogin replaces ldapLogin, incorporating our loginModal html styles
- added template extension package
- template myLdapLogin inherits ldapLogin events/helpers/hooks from tdamsma:meteor-accounts-ldap package
- corrected user group from "Students" to "Student"
- temporary "if logged in" pop up will need to be changed
- toast (Materialize.toast("Logged in as " + email, 2000, 'rounded')) was lost in process
